### PR TITLE
Custom plugin tabs (Part 1)

### DIFF
--- a/conf/tabs.php
+++ b/conf/tabs.php
@@ -166,6 +166,23 @@ if (empty($conf["useacl"]) || //are there any users?
 
 }
 
+//custom plugin tab
+$skip_types = ['backlink', 'create', 'edit', 'export_odt', 'export_pdf', 'revs', 'show', 'top'];
+foreach((new \dokuwiki\Menu\PageMenu())->getItems() as $item) {
+    if(in_array($item->getType(), $skip_types)) {
+        continue;
+    }
+
+    $_vector_tabs_right["tab-" . $item->getType()]["text"]     = $item->getLabel();
+    $_vector_tabs_right["tab-" . $item->getType()]["href"]     = $item->getLink();
+    if ($item->getType() == "menuitem") {
+        $_vector_tabs_right["tab-" . $item->getType()]["class"]    = "plugin_move_page";
+    } else {
+        $_vector_tabs_right["tab-" . $item->getType()]["class"]    = $item->getType();
+    }
+    $_vector_tabs_right["tab-" . $item->getType()]["nofollow"] = true;
+}
+
 /******************************************************************************
  ********************************  ATTENTION  *********************************
          DO NOT MODIFY THIS FILE, IT WILL NOT BE PRESERVED ON UPDATES!


### PR DESCRIPTION
The vector template doesn't handle MENU_ITEMS_ASSEMBLY event, so plugins that relies on this event to add buttons to menus (like deletepagebutton and bookcreator plugins) doesn't show up it's icon/link (button). But we can foreach each PageMenu item and add it's icon/link manually. The ideal would be handle this event so the template can properly handle plugins addons (icons/buttons), because this hack is not fail-prof: plugins that embeds javascript into the page may not load because it's functionality requires a JS file that is appended to the page by MENU_ITEMS_ASSEMBLY event.